### PR TITLE
set initial filter via command line flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,10 +21,13 @@ import (
 
 var updateVersion bool
 var version string = "dev"
+var initialFilter string
 
 func init() {
 	log.Init()
 	flag.BoolVar(&updateVersion, "update", false, "Pass this flag to update the gossh version to latest github release and exit")
+	flag.StringVar(&initialFilter, "filter", "", "Pass this flag to filter the initial list of connections")
+	flag.StringVar(&initialFilter, "f", "", "shorthand for filter")
 }
 
 func updateExecutable() error {
@@ -111,7 +114,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	lm, err := menus.ConnectionList()
+	lm, err := menus.ConnectionList(initialFilter)
 	if err != nil {
 		log.Logger.Error("Error running program: ", err)
 		os.Exit(1)

--- a/internal/menus/connectionlist.go
+++ b/internal/menus/connectionlist.go
@@ -244,9 +244,12 @@ func newConnectionlistModel(items []list.Item) connectionlistModel {
 	return m
 }
 
-func ConnectionList() (*connectionlistModel, error) {
+func ConnectionList(initialFilter string) (*connectionlistModel, error) {
 	items := config.ReadConnections()
 	m := newConnectionlistModel(items)
+	if initialFilter != "" {
+		m.list.SetFilterText(initialFilter)
+	}
 	p := tea.NewProgram(m, tea.WithAltScreen())
 
 	fm, err := p.Run()


### PR DESCRIPTION
* Sets the initial filter of the connections list via a flag `-f` or `-filter`